### PR TITLE
Update superagent w/ npm auto-update

### DIFF
--- a/packages/s/superagent.json
+++ b/packages/s/superagent.json
@@ -19,6 +19,12 @@
     "target": "superagent",
     "fileMap": [
       {
+        "basePath": "dist",
+        "files": [
+          "superagent*.+(js|map)"
+        ]
+      },
+      {
         "basePath": "",
         "files": [
           "superagent*.+(js|map)"


### PR DESCRIPTION
Newer versions of superagent are found in the dist folder and are currently missing from cdnjs.com